### PR TITLE
Update artifact names with run number

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: pylint-logs
+        name: pylint-logs${{ github.run_number }}
         path: tests-results/linting/pylint.log
         retention-days: 30
 
@@ -58,7 +58,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: test-results
+        name: test-results-${{ github.run_number }}
         path: tests-results/pytest
         retention-days: 30
 
@@ -84,7 +84,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: coverage-results
+        name: coverage-results-${{ github.run_number }}
         path: coverage.xml
         retention-days: 30
 


### PR DESCRIPTION
This PR updates the artifact names in the GitHub Actions workflow to include the run number. This ensures that each run of the workflow produces unique artifact names, making it easier to identify and manage artifacts.