### PR TITLE
Update artifact names to include Python version

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: pylint-logs${{ github.run_number }}
+        name: pylint-logs${{ matrix.python-version }}
         path: tests-results/linting/pylint.log
         retention-days: 30
 
@@ -58,7 +58,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: test-results-${{ github.run_number }}
+        name: test-results-${{ matrix.python-version }}
         path: tests-results/pytest
         retention-days: 30
 
@@ -84,7 +84,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: coverage-results-${{ github.run_number }}
+        name: coverage-results-${{ matrix.python-version }}
         path: coverage.xml
         retention-days: 30
 


### PR DESCRIPTION
This PR updates the artifact names in the GitHub Actions workflow to include the Python version. This ensures that the artifacts are easily identifiable and organized based on the Python version used in the workflow.