### PR TITLE
Add conditional check for pull request event

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   lint:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
This pull request adds a conditional check for the pull request event. It ensures that the code is only executed when the event is a push or a pull request from a different repository.