### PR TITLE
Fix artifact name and enable pre-release publishing

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: pylint-logs${{ matrix.python-version }}
+        name: pylint-logs-${{ matrix.python-version }}
         path: tests-results/linting/pylint.log
         retention-days: 30
 
@@ -98,8 +98,10 @@ jobs:
     needs: test
     steps:
     - uses: actions/checkout@v4
-    - name: Build and publish to pypi registry
+    - name: Build and publish to pypi
       uses: JRubics/poetry-publish@v2.0
       with:
-        python-version: "3.9.1"
+        python_version: "3.9.1"
         pypi_token: ${{ secrets.PYPI_TOKEN }}
+        allow_poetry_pre_release: "yes"
+


### PR DESCRIPTION
This pull request fixes the artifact name in the upload-artifact step and enables pre-release publishing to the PyPI registry.